### PR TITLE
Return response in Stream#update!

### DIFF
--- a/lib/m2x/stream.rb
+++ b/lib/m2x/stream.rb
@@ -49,9 +49,9 @@ class M2X::Client::Stream < M2X::Client::Resource
   # @return {Stream} The newly created stream
   #
   def update!(params)
-    res = @client.put(path, {}, params, "Content-Type" => "application/json")
-
-    @attributes = res.json if res.status == 201
+    @client.put(path, {}, params, "Content-Type" => "application/json").tap do |res|
+      @attributes = res.json if res.status == 201
+    end
   end
 
   #


### PR DESCRIPTION
Currently we don't see the response of the stream update request, so in case of validations errors we cannot find out why the validation has failed.

So we change `Stream#update!` to always return the response of the operation, which is aligned with the default `Resource#update!` method.